### PR TITLE
Password Prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import argparse
 import os
 import platform
 import sys
+from getpass import getpass
 
 import config
 import login
@@ -49,9 +50,11 @@ def main():
 		os.system("clear")
 	parser = argparse.ArgumentParser()
 	parser.add_argument("-u", "--username", help="Login", required=True)
-	parser.add_argument("-p", "--password", help="Password", required=True)
+	parser.add_argument("-p", "--password", help="Password", default=None)
 	parser.add_argument("-t", "--type", help="Google/PTC", required=True)
 	args = parser.parse_args()
+	if not args.password:
+		args.password = getpass("Google/PTC Password: ")
 	if 'ptc' in args.type.lower() or 'goo' in args.type.lower():
 		access_token,ltype=get_acces_token(args.username,args.password,args.type.lower())
 		if access_token is not None:


### PR DESCRIPTION
Added support for password prompt. Password as an argument is still an option. If no argument passed, user will be prompted.  This is better for *nix like OSs (keeps password out of history and allows complex passwords that might fail as arguments).