### PR TITLE
adds s2sphere to project requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests==2.10.0
 protobuf==2.6.1
 geopy==1.11.0
 gpsoauth==0.3.0
+s2sphere==0.2.4


### PR DESCRIPTION
`requirements.txt` did not include all requirements for the project.

This adds the missing requirement of `s2sphere` to the `requirements.txt`.