### PR TITLE
Fixed issue with SSL certificate

### DIFF
--- a/location.py
+++ b/location.py
@@ -31,7 +31,7 @@ def set_lot(new):
 	COORDS_LONGITUDE= f2i(new)
 	
 def set_location(location_name):
-	geolocator = GoogleV3()
+	geolocator = GoogleV3(scheme='http')
 	loc = geolocator.geocode(location_name)
 
 	print('[!] Your given location: {}'.format(loc.address.encode('utf-8')))


### PR DESCRIPTION
Some users might have issues with https, which is set default.
Explicitly set scheme to http.

geopy.exc.GeocoderServiceError: <urlopen error [SSL:
CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)>